### PR TITLE
Add UserDefaults observation functions

### DIFF
--- a/Sources/RIDIFoundation/Extensions/Foundation/UserDefaults.swift
+++ b/Sources/RIDIFoundation/Extensions/Foundation/UserDefaults.swift
@@ -170,6 +170,74 @@ extension UserDefaultsBindable {
     }
 }
 
+// MARK: - Observation
+
+extension UserDefaults {
+    public struct KeyValueObservedChange<Value> {
+        public typealias Kind = NSKeyValueChange
+
+        public let kind: KeyValueObservedChange<Value>.Kind
+
+        ///newValue and oldValue will only be non-nil if .new/.old is passed to `observe()`. In general, get the most up to date value by accessing it directly on the observed object instead.
+        public let newValue: Value?
+
+        public let oldValue: Value?
+
+        ///indexes will be nil unless the observed KeyPath refers to an ordered to-many property
+        public let indexes: IndexSet?
+
+        ///'isPrior' will be true if this change observation is being sent before the change happens, due to .prior being passed to `observe()`
+        public let isPrior: Bool
+    }
+
+    public class KeyValueObservation<Value>: NSObject {
+        private unowned let userDefaults: UserDefaults
+        private let key: Key<Value>
+        private var changeHandler: (UserDefaults, KeyValueObservedChange<Value>) -> Void
+
+        init(userDefaults: UserDefaults = .standard, key: Key<Value>, options: NSKeyValueObservingOptions, changeHandler: @escaping (UserDefaults, KeyValueObservedChange<Value>) -> Void) {
+            self.userDefaults = userDefaults
+            self.changeHandler = changeHandler
+            self.key = key
+            super.init()
+            userDefaults.addObserver(self, forKeyPath: key.rawValue, options: options, context: nil)
+        }
+
+        public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+            guard let change = change, object != nil, keyPath == key.rawValue else { return }
+            changeHandler(
+                userDefaults,
+                KeyValueObservedChange(
+                    kind: NSKeyValueChange(rawValue: change[.kindKey] as! UInt)!,
+                    newValue: change[.newKey] as? Value,
+                    oldValue: change[.oldKey] as? Value,
+                    indexes: change[.indexesKey] as? IndexSet,
+                    isPrior: change[.notificationIsPriorKey] as? Bool == true
+                )
+            )
+        }
+
+        deinit {
+            userDefaults.removeObserver(self, forKeyPath: key.rawValue, context: nil)
+        }
+    }
+
+    public func observe<Value>(_ key: Key<Value>, options: NSKeyValueObservingOptions = [.new], changeHandler: @escaping (UserDefaults, KeyValueObservedChange<Value>) -> Void) -> UserDefaults.KeyValueObservation<Value> {
+        
+        KeyValueObservation<Value>(userDefaults: self, key: key, options: options, changeHandler: changeHandler)
+    }
+}
+
+extension UserDefaultsBindable {
+    public func observe(options: NSKeyValueObservingOptions = [.new], _ changeHandler: @escaping (Self, UserDefaults.KeyValueObservedChange<ValueType>) -> Void) -> UserDefaults.KeyValueObservation<ValueType> {
+        userDefaults.observe(self.key, options: options) {
+            changeHandler(self, $1)
+        }
+    }
+}
+
+// MARK: -
+
 extension UserDefaults {
     @propertyWrapper
     public struct Binding<T>: UserDefaultsBindable {

--- a/Sources/RIDIFoundation/Extensions/Foundation/UserDefaults.swift
+++ b/Sources/RIDIFoundation/Extensions/Foundation/UserDefaults.swift
@@ -238,7 +238,6 @@ extension UserDefaults {
         options: NSKeyValueObservingOptions = [.new],
         changeHandler: @escaping (UserDefaults, KeyValueObservedChange<Value>) -> Void
     ) -> UserDefaults.KeyValueObservation<Value> {
-        
         KeyValueObservation<Value>(userDefaults: self, key: key, options: options, changeHandler: changeHandler)
     }
 }

--- a/Sources/RIDIFoundation/Extensions/Foundation/UserDefaults.swift
+++ b/Sources/RIDIFoundation/Extensions/Foundation/UserDefaults.swift
@@ -178,7 +178,8 @@ extension UserDefaults {
 
         public let kind: KeyValueObservedChange<Value>.Kind
 
-        ///newValue and oldValue will only be non-nil if .new/.old is passed to `observe()`. In general, get the most up to date value by accessing it directly on the observed object instead.
+        ///newValue and oldValue will only be non-nil if .new/.old is passed to `observe()`.
+        ///In general, get the most up to date value by accessing it directly on the observed object instead.
         public let newValue: Value?
 
         public let oldValue: Value?
@@ -186,7 +187,8 @@ extension UserDefaults {
         ///indexes will be nil unless the observed KeyPath refers to an ordered to-many property
         public let indexes: IndexSet?
 
-        ///'isPrior' will be true if this change observation is being sent before the change happens, due to .prior being passed to `observe()`
+        ///'isPrior' will be true if this change observation is being sent before the change happens,
+        ///due to .prior being passed to `observe()`
         public let isPrior: Bool
     }
 
@@ -195,7 +197,11 @@ extension UserDefaults {
         private let key: Key<Value>
         private var changeHandler: (UserDefaults, KeyValueObservedChange<Value>) -> Void
 
-        init(userDefaults: UserDefaults = .standard, key: Key<Value>, options: NSKeyValueObservingOptions, changeHandler: @escaping (UserDefaults, KeyValueObservedChange<Value>) -> Void) {
+        init(
+            userDefaults: UserDefaults = .standard,
+            key: Key<Value>, options: NSKeyValueObservingOptions,
+            changeHandler: @escaping (UserDefaults, KeyValueObservedChange<Value>) -> Void
+        ) {
             self.userDefaults = userDefaults
             self.changeHandler = changeHandler
             self.key = key
@@ -203,7 +209,12 @@ extension UserDefaults {
             userDefaults.addObserver(self, forKeyPath: key.rawValue, options: options, context: nil)
         }
 
-        public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        public override func observeValue(
+            forKeyPath keyPath: String?,
+            of object: Any?,
+            change: [NSKeyValueChangeKey: Any]?,
+            context: UnsafeMutableRawPointer?
+        ) {
             guard let change = change, object != nil, keyPath == key.rawValue else { return }
             changeHandler(
                 userDefaults,
@@ -222,14 +233,21 @@ extension UserDefaults {
         }
     }
 
-    public func observe<Value>(_ key: Key<Value>, options: NSKeyValueObservingOptions = [.new], changeHandler: @escaping (UserDefaults, KeyValueObservedChange<Value>) -> Void) -> UserDefaults.KeyValueObservation<Value> {
+    public func observe<Value>(
+        _ key: Key<Value>,
+        options: NSKeyValueObservingOptions = [.new],
+        changeHandler: @escaping (UserDefaults, KeyValueObservedChange<Value>) -> Void
+    ) -> UserDefaults.KeyValueObservation<Value> {
         
         KeyValueObservation<Value>(userDefaults: self, key: key, options: options, changeHandler: changeHandler)
     }
 }
 
 extension UserDefaultsBindable {
-    public func observe(options: NSKeyValueObservingOptions = [.new], _ changeHandler: @escaping (Self, UserDefaults.KeyValueObservedChange<ValueType>) -> Void) -> UserDefaults.KeyValueObservation<ValueType> {
+    public func observe(
+        options: NSKeyValueObservingOptions = [.new],
+        _ changeHandler: @escaping (Self, UserDefaults.KeyValueObservedChange<ValueType>) -> Void
+    ) -> UserDefaults.KeyValueObservation<ValueType> {
         userDefaults.observe(self.key, options: options) {
             changeHandler(self, $1)
         }

--- a/Sources/RIDIFoundation/XML/XMLElement.swift
+++ b/Sources/RIDIFoundation/XML/XMLElement.swift
@@ -74,4 +74,3 @@ open class XMLElement: XMLNode {
         attributes?.first(where: { $0.name == name })
     }
 }
-

--- a/Tests/RIDIFoundationTests/Extensions/Foundation/UserDefaultsTest.swift
+++ b/Tests/RIDIFoundationTests/Extensions/Foundation/UserDefaultsTest.swift
@@ -154,6 +154,48 @@ final class UserDefaultsTests: XCTestCase {
         )
     }
 
+    func testObservation() {
+        let key = UserDefaults.Key<String>(UUID().uuidString)
+        let userDefaults = UserDefaults.standard
+
+        let newValue = UUID().uuidString
+
+        let expectation = XCTestExpectation(description: "Notified")
+        expectation.expectedFulfillmentCount = 1
+
+        let observation = userDefaults.observe(key) {
+            XCTAssertEqual($0, userDefaults)
+            XCTAssertEqual($1.newValue, newValue)
+
+            expectation.fulfill()
+        }
+
+        userDefaults[key] = newValue
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testObservationPrior() {
+        let key = UserDefaults.Key<String>(UUID().uuidString)
+        let userDefaults = UserDefaults.standard
+
+        let newValue = UUID().uuidString
+
+        let expectation = XCTestExpectation(description: "Notified")
+        expectation.expectedFulfillmentCount = 2
+
+        let observation = userDefaults.observe(key, options: [.prior, .new]) {
+            XCTAssertEqual($0, userDefaults)
+            _ = $1
+
+            expectation.fulfill()
+        }
+
+        userDefaults[key] = newValue
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
     static var allTests = [
         ("testBinding", testBinding),
         ("testSubscript", testSubscript),

--- a/Tests/RIDIFoundationTests/Extensions/Foundation/UserDefaultsTest.swift
+++ b/Tests/RIDIFoundationTests/Extensions/Foundation/UserDefaultsTest.swift
@@ -205,6 +205,8 @@ final class UserDefaultsTests: XCTestCase {
         ("testBoolSubscript", testBoolSubscript),
         ("testCodable", testCodable),
         ("testCodableBinding", testCodableBinding),
-        ("testCodableBindingWithTopLevel", testCodableBindingWithTopLevel)
+        ("testCodableBindingWithTopLevel", testCodableBindingWithTopLevel),
+        ("testObservation", testObservation),
+        ("testObservationPrior", testObservationPrior)
     ]
 }


### PR DESCRIPTION
## Summary

- This will introduce new `observe` functions to `UserDefaults`, `UserDefaults.Binding*`

## Change Logs

- Add `KeyValueObservedChange` which almost same as `Foundation.NSKeyValueObservedChange`
- Add `KeyValueObservation` which almost same as `Foundation.NSKeyValueObservation`
- Add `observe` functions to `UserDefaults`, `UserDefaults.Binding*`

---

## 요약

- `UserDefaults`, `UserDefaults.Binding*`에 `observe` function을 추가합니다.

## 변경사항

- `Foundation.NSKeyValueObservedChange`와 비슷한 `KeyValueObservedChange`를 추가합니다.
- `Foundation.NSKeyValueObservation`와 비슷한 `KeyValueObservation`를 추가합니다.
- `UserDefaults`, `UserDefaults.Binding*`에 `observe` function을 추가합니다.