### PR TITLE
books, RIDIUIKit 공통 Dependency인 Bool extension 추가

### DIFF
--- a/Sources/RIDIFoundation/Extensions/Foundation/Bool+Extension.swift
+++ b/Sources/RIDIFoundation/Extensions/Foundation/Bool+Extension.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Bool {
+  func not() -> Bool {
+    return !self
+  }
+}

--- a/Sources/RIDIFoundation/Extensions/Foundation/Bool+Extension.swift
+++ b/Sources/RIDIFoundation/Extensions/Foundation/Bool+Extension.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Bool {
-  func not() -> Bool {
+  public func not() -> Bool {
     return !self
   }
 }


### PR DESCRIPTION
## 요약
- [swiftlint, swiftformat 정리작업](https://github.com/ridi/ridi/pull/4031) 과정에 books, RIDIUIKit에서 중복으로 정의하는 Bool extension을 공통 dependency인 RIDIFoundation에 추가합니다.

## 작업내용
- bool extension 추가 (c601982fc093ef7b5d8282277510ec5688f8e923, 9e08acc36022e9aed3f1a3b48c1241757bfc295c)

## 참고사항
- 해당 커밋으로 받아온 dependency로 테스트는 완료했습니다.
- [swiftlint, swiftformat 정리작업](https://github.com/ridi/ridi/pull/4031) 이 Merge되기 전에 선반영이 필요합니다.