### PR TITLE
workflow의 mac os, xcode version 명시적으로 수정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,14 @@ jobs:
   
     strategy:
       fail-fast: false
-      matrix:
-        operating-system: [macOS-latest]
-        xcode-version: ["11.3.1", "11.4.1", "11.5", "11.6", "12.0"]
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2
-    - uses: sinoru/actions-setup-xcode@v1.1
+    - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: ${{ matrix.xcode-version }}
+        xcode-version: 13.0
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
## 요약
- CI의 테스트 과정에서 실패하는 xcode 설치 및 mac os와 xcode버전이 호환되지 않을 수 있는 문제를 수정합니다.

## 작업내용
- CI step에서 실행되는 mac os, xcode version을 명시적으로 수정합니다. (b952495bd6492369fc2f13ef277a8066a5497035)

## 궁금한 사항
- workflow를 수정하면 CI가 잘 동작하는지 PR올리기 전에 따로 테스트 해볼 수 있나요?
- [Xcode버전과 mac os 호환](https://developer.apple.com/kr/support/xcode/)에 의하면 Xcode 13을 사용하려면 최소 OS가 mac os 11.3 인데, [모노레포](https://github.com/ridi/ridi/blob/master/.github/workflows/ridibooks-ios.yml)를 보면 mac os 11, Xcode 13.0으로 명시적으로 설정되어 있는데 이게 왜 괜찮을까요..?? 작업은 모노레포 버전 기준으로 맞춰두긴 했습니다.